### PR TITLE
Still show component if blinking is false

### DIFF
--- a/BlinkView.js
+++ b/BlinkView.js
@@ -103,7 +103,7 @@ export default class BlinkView extends Component
   {
     try
     {
-      const isBlinking:bolean = this.props && this.props.blinking || true;
+      const isBlinking: bolean = (this.props && this.props.blinking) || false;
       const Element:any = ( ( isBlinking === true ) ? Animated.createAnimatedComponent( this.props && this.props.element || View ) : this.props && this.props.element || View );
 
       return  (


### PR DESCRIPTION
I use BlinkView instead of View.
If `blinking` is false or true, the View doesn't show.
It supposed to display the View if blinking is false